### PR TITLE
Add Go to Today button on tasks page

### DIFF
--- a/src/app/tasks/page.js
+++ b/src/app/tasks/page.js
@@ -2,6 +2,7 @@ import HorizontalCalendar from "@/components/HorizontalCalendar/HorizontalCalend
 import TodosArea from "@/components/TodosArea/TodosArea";
 import TodoInput from "@/components/TodoInput/TodoInput";
 import BgDimmer from "@/components/BgDimmer/BgDimmer";
+import GoToTodayButton from "@/components/GoToTodayButton/GoToTodayButton";
 import { headers } from "next/headers";
 import React from "react";
 import { auth } from "../../../lib/auth";
@@ -25,6 +26,9 @@ export default async function Home() {
   return (
     <>
       <HorizontalCalendar />
+      <div className="flex justify-center pt-4">
+        <GoToTodayButton />
+      </div>
       <div className="flex flex-col py-6 gap-8 items-center justify-center">
         <TodosArea />
         <TodoInput />

--- a/src/components/GoToTodayButton/GoToTodayButton.js
+++ b/src/components/GoToTodayButton/GoToTodayButton.js
@@ -1,0 +1,21 @@
+"use client"
+import { CalendarDays } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import useTodo from "@/hooks/useTodo"
+
+const GoToTodayButton = () => {
+  const { setSelectedDate } = useTodo()
+
+  const handleGoToToday = () => {
+    setSelectedDate(new Date())
+  }
+
+  return (
+    <Button onClick={handleGoToToday} variant="outline" className="shadow-md rounded-full">
+      Go to Today
+      <CalendarDays />
+    </Button>
+  )
+}
+
+export default GoToTodayButton

--- a/src/components/HorizontalCalendar/HorizontalCalendar.js
+++ b/src/components/HorizontalCalendar/HorizontalCalendar.js
@@ -3,7 +3,7 @@ import { ChevronLeft } from "lucide-react"
 import { ChevronRight } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { addDays, format, isSameDay, startOfWeek } from "date-fns"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import TimeBar from "@/components/TimeBar/TimeBar"
 import { useSwipeable } from "react-swipeable"
 import useStatedata from "@/hooks/useStatedata"
@@ -17,6 +17,10 @@ const HorizontalCalendar = () => {
   } = useTodo();
   const [currentDate, setCurrentDate] = useState(selectedDate);
   // const [currentDate, setCurrentDate] = useState(new Date())
+
+  useEffect(() => {
+    setCurrentDate(selectedDate)
+  }, [selectedDate])
 
   const handleNextWeek = () => {
     setCurrentDate(addDays(currentDate, 7))


### PR DESCRIPTION
## Summary
- Add a Go To Today button to the /tasks header
- Sync the horizontal calendar view to selected date

## Testing
- Not run (local lint previously failed due to parser serialization error)
